### PR TITLE
[1.19] Effective tool for Vertical Planks

### DIFF
--- a/forge/src/main/java/net/mehvahdjukaar/every_compat/modules/quark/QuarkModule.java
+++ b/forge/src/main/java/net/mehvahdjukaar/every_compat/modules/quark/QuarkModule.java
@@ -145,6 +145,7 @@ public class QuarkModule extends SimpleModule {
                             return new QuarkBlock(name, m, CreativeModeTab.TAB_BUILDING_BLOCKS, Utils.copyPropertySafe(w.planks));
                         })
                 .setTab(() -> CreativeModeTab.TAB_BUILDING_BLOCKS)
+                .addTag(BlockTags.MINEABLE_WITH_AXE, Registry.BLOCK_REGISTRY)
                 .addTag(BlockTags.PLANKS, Registry.BLOCK_REGISTRY)
                 .addRecipe(modRes("building/crafting/vertplanks/vertical_oak_planks"))
                 .build();


### PR DESCRIPTION
This PR adds to the 1.19 version of this mod the minable-with-axe tag to the generated vertical planks (Quark).

To fix the related 1.18 issue #48 this change could be backported. :)
