### PR TITLE
Give FD cabinets missing "cabinets/wooden" tag

### DIFF
--- a/forge/src/main/java/net/mehvahdjukaar/every_compat/modules/farmersdelight/FarmersDelightModule.java
+++ b/forge/src/main/java/net/mehvahdjukaar/every_compat/modules/farmersdelight/FarmersDelightModule.java
@@ -31,6 +31,7 @@ public class FarmersDelightModule extends SimpleModule {
                         w -> new CompatCabinetBlock(Utils.copyPropertySafe(w.planks)))
                 .addTag(modRes("cabinets"), Registry.BLOCK_REGISTRY)
                 .addTag(modRes("cabinets"), Registry.ITEM_REGISTRY)
+                .addTag(modRes("cabinets/wooden"), Registry.ITEM_REGISTRY)
                 .addTag(BlockTags.MINEABLE_WITH_AXE, Registry.BLOCK_REGISTRY)
                 .defaultRecipe()
                 .addTile(CompatCabinetBlockTile::new)


### PR DESCRIPTION
The tag exists as of 1.19 Farmer's Delight
Seen here:
https://github.com/vectorwing/FarmersDelight/blob/1.19/src/main/java/vectorwing/farmersdelight/common/tag/ModTags.java