### PR TITLE
Updated Woodster compat for 1.20+

### DIFF
--- a/forge/src/main/java/net/mehvahdjukaar/every_compat/modules/forge/woodster/WoodsterModule.java
+++ b/forge/src/main/java/net/mehvahdjukaar/every_compat/modules/forge/woodster/WoodsterModule.java
@@ -25,13 +25,8 @@ public class WoodsterModule extends SimpleModule {
         super(modId, "wdst");
 
         chiseled_books = SimpleEntrySet.builder(WoodType.class, "chiseled_bookshelf",
-                        WoodsterBlocks.OAK_CHISELED_BOOKSHELF, () -> WoodTypeRegistry.OAK_TYPE,
+                        WoodsterBlocks.DARK_OAK_CHISELED_BOOKSHELF, () -> WoodTypeRegistry.OAK_TYPE,
                         w -> new ChiseledBookshelfBlock(Utils.copyPropertySafe(w.planks)))
-                .addTextureM(modRes("block/oak_chiseled_bookshelf_1"),modRes( "block/everycomp_chiseled_bookshelf_1"))
-                .addTextureM(modRes("block/oak_chiseled_bookshelf_2"),modRes( "block/everycomp_chiseled_bookshelf_2"))
-                .addTextureM(modRes("block/oak_chiseled_bookshelf_3"),modRes( "block/everycomp_chiseled_bookshelf_3"))
-                .addTextureM(modRes("block/oak_chiseled_bookshelf_4"),modRes( "block/everycomp_chiseled_bookshelf_4"))
-                .addTextureM(modRes("block/oak_chiseled_bookshelf_5"),modRes( "block/everycomp_chiseled_bookshelf_5"))
                 .addTextureM(modRes("block/oak_chiseled_bookshelf_6"),modRes( "block/everycomp_chiseled_bookshelf_6"))
                 .addTexture(modRes("block/oak_chiseled_bookshelf_side"))
                 .addTexture(modRes("block/oak_chiseled_bookshelf_top"))


### PR DESCRIPTION
I've updated the Woodster compatibility since the Oak Chiseled Bookshelf is now in vanilla & what not, as well as a texture change overall. Though I'll have to update Woodster on my end too just to re-add the oak textures for WoodCompat to use as I didn't found any Chiseled Bookshelf base textures in the WoodCompat mod itself like with the ladder & normal bookshelf.