### PR TITLE
[1.19.2] Update Dramatic Doors module

### DIFF
--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -137,7 +137,7 @@ dependencies {
     modCompileOnly("curse.maven:chipped-456956:4463479")
     modCompileOnly("curse.maven:create-328085:4547147")
     modCompileOnly("curse.maven:decorative-blocks-362528:3941638")
-    modCompileOnly("curse.maven:dramatic-doors-380617:4507455")
+    modCompileOnly("curse.maven:dramatic-doors-380617:4803790")
     modCompileOnly("curse.maven:domum-ornamentum-527361:4174257")
     modCompileOnly("curse.maven:exlines-bark-carpets-527296:4094399")
     modImplementation("curse.maven:farmersdelight-398521:3999157")

--- a/forge/src/main/java/net/mehvahdjukaar/every_compat/modules/forge/dramaticdoors/DramaticDoorsMacawModule.java
+++ b/forge/src/main/java/net/mehvahdjukaar/every_compat/modules/forge/dramaticdoors/DramaticDoorsMacawModule.java
@@ -1,9 +1,9 @@
 package net.mehvahdjukaar.every_compat.modules.forge.dramaticdoors;
 
-import com.fizzware.dramaticdoors.DramaticDoors;
-import com.fizzware.dramaticdoors.blocks.TallDoorBlock;
-import com.fizzware.dramaticdoors.blocks.TallSlidingDoorBlock;
-import com.fizzware.dramaticdoors.blocks.TallStableDoorBlock;
+import com.fizzware.dramaticdoors.forge.DDRegistry;
+import com.fizzware.dramaticdoors.forge.blocks.TallDoorBlock;
+import com.fizzware.dramaticdoors.forge.blocks.TallSlidingDoorBlock;
+import com.fizzware.dramaticdoors.forge.blocks.TallStableDoorBlock;
 import com.mcwdoors.kikoz.init.BlockInit;
 import net.mehvahdjukaar.every_compat.EveryCompat;
 import net.mehvahdjukaar.every_compat.api.SimpleEntrySet;
@@ -59,7 +59,7 @@ public class DramaticDoorsMacawModule extends SimpleModule {
                 .addTag(modRes("tall_wooden_doors"), Registry.ITEM_REGISTRY)
                 .addTag(BlockTags.MINEABLE_WITH_AXE, Registry.BLOCK_REGISTRY)
                 .setRenderType(() -> RenderType::cutout)
-                .setTab(() -> DramaticDoors.MAIN_TAB)
+                .setTab(() -> DDRegistry.MAIN_TAB)
                 .copyParentDrop()
                 .defaultRecipe()
                 .build();
@@ -78,7 +78,7 @@ public class DramaticDoorsMacawModule extends SimpleModule {
                 .addTag(modRes("tall_wooden_doors"), Registry.ITEM_REGISTRY)
                 .addTag(BlockTags.MINEABLE_WITH_AXE, Registry.BLOCK_REGISTRY)
                 .setRenderType(() -> RenderType::cutout)
-                .setTab(() -> DramaticDoors.MAIN_TAB)
+                .setTab(() -> DDRegistry.MAIN_TAB)
                 .copyParentDrop()
                 .defaultRecipe()
                 .build();
@@ -97,7 +97,7 @@ public class DramaticDoorsMacawModule extends SimpleModule {
                 .addTag(modRes("tall_wooden_doors"), Registry.ITEM_REGISTRY)
                 .addTag(BlockTags.MINEABLE_WITH_AXE, Registry.BLOCK_REGISTRY)
                 .setRenderType(() -> RenderType::cutout)
-                .setTab(() -> DramaticDoors.MAIN_TAB)
+                .setTab(() -> DDRegistry.MAIN_TAB)
                 .copyParentDrop()
                 .defaultRecipe()
                 .build();
@@ -116,7 +116,7 @@ public class DramaticDoorsMacawModule extends SimpleModule {
                 .addTag(modRes("tall_wooden_doors"), Registry.ITEM_REGISTRY)
                 .addTag(BlockTags.MINEABLE_WITH_AXE, Registry.BLOCK_REGISTRY)
                 .setRenderType(() -> RenderType::cutout)
-                .setTab(() -> DramaticDoors.MAIN_TAB)
+                .setTab(() -> DDRegistry.MAIN_TAB)
                 .copyParentDrop()
                 .defaultRecipe()
                 .build();
@@ -132,7 +132,7 @@ public class DramaticDoorsMacawModule extends SimpleModule {
                 .addTag(modRes("tall_wooden_doors"), Registry.ITEM_REGISTRY)
                 .addTag(BlockTags.MINEABLE_WITH_AXE, Registry.BLOCK_REGISTRY)
                 .setRenderType(() -> RenderType::cutout)
-                .setTab(() -> DramaticDoors.MAIN_TAB)
+                .setTab(() -> DDRegistry.MAIN_TAB)
                 .copyParentDrop()
                 .defaultRecipe()
                 .build();
@@ -151,7 +151,7 @@ public class DramaticDoorsMacawModule extends SimpleModule {
                 .addTag(modRes("tall_wooden_doors"), Registry.ITEM_REGISTRY)
                 .addTag(BlockTags.MINEABLE_WITH_AXE, Registry.BLOCK_REGISTRY)
                 .setRenderType(() -> RenderType::cutout)
-                .setTab(() -> DramaticDoors.MAIN_TAB)
+                .setTab(() -> DDRegistry.MAIN_TAB)
                 .copyParentDrop()
                 .defaultRecipe()
                 .build();
@@ -170,7 +170,7 @@ public class DramaticDoorsMacawModule extends SimpleModule {
                 .addTag(modRes("tall_wooden_doors"), Registry.ITEM_REGISTRY)
                 .addTag(BlockTags.MINEABLE_WITH_AXE, Registry.BLOCK_REGISTRY)
                 .setRenderType(() -> RenderType::cutout)
-                .setTab(() -> DramaticDoors.MAIN_TAB)
+                .setTab(() -> DDRegistry.MAIN_TAB)
                 .copyParentDrop()
                 .defaultRecipe()
                 .build();
@@ -189,7 +189,7 @@ public class DramaticDoorsMacawModule extends SimpleModule {
                 .addTag(modRes("tall_wooden_doors"), Registry.ITEM_REGISTRY)
                 .addTag(BlockTags.MINEABLE_WITH_AXE, Registry.BLOCK_REGISTRY)
                 .setRenderType(() -> RenderType::cutout)
-                .setTab(() -> DramaticDoors.MAIN_TAB)
+                .setTab(() -> DDRegistry.MAIN_TAB)
                 .copyParentDrop()
                 .defaultRecipe()
                 .build();
@@ -208,7 +208,7 @@ public class DramaticDoorsMacawModule extends SimpleModule {
                 .addTag(modRes("tall_wooden_doors"), Registry.ITEM_REGISTRY)
                 .addTag(BlockTags.MINEABLE_WITH_AXE, Registry.BLOCK_REGISTRY)
                 .setRenderType(() -> RenderType::cutout)
-                .setTab(() -> DramaticDoors.MAIN_TAB)
+                .setTab(() -> DDRegistry.MAIN_TAB)
                 .copyParentDrop()
                 .defaultRecipe()
                 .build();
@@ -227,7 +227,7 @@ public class DramaticDoorsMacawModule extends SimpleModule {
                 .addTag(modRes("tall_wooden_doors"), Registry.ITEM_REGISTRY)
                 .addTag(BlockTags.MINEABLE_WITH_AXE, Registry.BLOCK_REGISTRY)
                 .setRenderType(() -> RenderType::cutout)
-                .setTab(() -> DramaticDoors.MAIN_TAB)
+                .setTab(() -> DDRegistry.MAIN_TAB)
                 .copyParentDrop()
                 .defaultRecipe()
                 .build();
@@ -246,7 +246,7 @@ public class DramaticDoorsMacawModule extends SimpleModule {
                 .addTag(modRes("tall_wooden_doors"), Registry.ITEM_REGISTRY)
                 .addTag(BlockTags.MINEABLE_WITH_AXE, Registry.BLOCK_REGISTRY)
                 .setRenderType(() -> RenderType::cutout)
-                .setTab(() -> DramaticDoors.MAIN_TAB)
+                .setTab(() -> DDRegistry.MAIN_TAB)
                 .copyParentDrop()
                 .defaultRecipe()
                 .build();
@@ -265,7 +265,7 @@ public class DramaticDoorsMacawModule extends SimpleModule {
                 .addTag(modRes("tall_wooden_doors"), Registry.ITEM_REGISTRY)
                 .addTag(BlockTags.MINEABLE_WITH_AXE, Registry.BLOCK_REGISTRY)
                 .setRenderType(() -> RenderType::cutout)
-                .setTab(() -> DramaticDoors.MAIN_TAB)
+                .setTab(() -> DDRegistry.MAIN_TAB)
                 .copyParentDrop()
                 .defaultRecipe()
                 .build();
@@ -284,7 +284,7 @@ public class DramaticDoorsMacawModule extends SimpleModule {
                 .addTag(modRes("tall_wooden_doors"), Registry.ITEM_REGISTRY)
                 .addTag(BlockTags.MINEABLE_WITH_AXE, Registry.BLOCK_REGISTRY)
                 .setRenderType(() -> RenderType::cutout)
-                .setTab(() -> DramaticDoors.MAIN_TAB)
+                .setTab(() -> DDRegistry.MAIN_TAB)
                 .copyParentDrop()
                 .defaultRecipe()
                 .build();
@@ -303,7 +303,7 @@ public class DramaticDoorsMacawModule extends SimpleModule {
                 .addTag(modRes("tall_wooden_doors"), Registry.ITEM_REGISTRY)
                 .addTag(BlockTags.MINEABLE_WITH_AXE, Registry.BLOCK_REGISTRY)
                 .setRenderType(() -> RenderType::cutout)
-                .setTab(() -> DramaticDoors.MAIN_TAB)
+                .setTab(() -> DDRegistry.MAIN_TAB)
                 .copyParentDrop()
                 .defaultRecipe()
                 .build();
@@ -322,7 +322,7 @@ public class DramaticDoorsMacawModule extends SimpleModule {
                 .addTag(modRes("tall_wooden_doors"), Registry.ITEM_REGISTRY)
                 .addTag(BlockTags.MINEABLE_WITH_AXE, Registry.BLOCK_REGISTRY)
                 .setRenderType(() -> RenderType::cutout)
-                .setTab(() -> DramaticDoors.MAIN_TAB)
+                .setTab(() -> DDRegistry.MAIN_TAB)
                 .copyParentDrop()
                 .defaultRecipe()
                 .build();
@@ -342,7 +342,7 @@ public class DramaticDoorsMacawModule extends SimpleModule {
                 .addTag(BlockTags.MINEABLE_WITH_AXE, Registry.BLOCK_REGISTRY)
                 .createPaletteFromOak(this::swampDoorPalette)
                 .setRenderType(() -> RenderType::cutout)
-                .setTab(() -> DramaticDoors.MAIN_TAB)
+                .setTab(() -> DDRegistry.MAIN_TAB)
                 .copyParentDrop()
                 .defaultRecipe()
                 .build();
@@ -361,7 +361,7 @@ public class DramaticDoorsMacawModule extends SimpleModule {
                 .addTag(modRes("tall_wooden_doors"), Registry.ITEM_REGISTRY)
                 .addTag(BlockTags.MINEABLE_WITH_AXE, Registry.BLOCK_REGISTRY)
                 .setRenderType(() -> RenderType::cutout)
-                .setTab(() -> DramaticDoors.MAIN_TAB)
+                .setTab(() -> DDRegistry.MAIN_TAB)
                 .copyParentDrop()
                 .defaultRecipe()
                 .build();
@@ -380,7 +380,7 @@ public class DramaticDoorsMacawModule extends SimpleModule {
                 .addTag(modRes("tall_wooden_doors"), Registry.ITEM_REGISTRY)
                 .addTag(BlockTags.MINEABLE_WITH_AXE, Registry.BLOCK_REGISTRY)
                 .setRenderType(() -> RenderType::cutout)
-                .setTab(() -> DramaticDoors.MAIN_TAB)
+                .setTab(() -> DDRegistry.MAIN_TAB)
                 .copyParentDrop()
                 .defaultRecipe()
                 .build();

--- a/forge/src/main/java/net/mehvahdjukaar/every_compat/modules/forge/dramaticdoors/DramaticDoorsModule.java
+++ b/forge/src/main/java/net/mehvahdjukaar/every_compat/modules/forge/dramaticdoors/DramaticDoorsModule.java
@@ -1,8 +1,8 @@
 package net.mehvahdjukaar.every_compat.modules.forge.dramaticdoors;
 
-import com.fizzware.dramaticdoors.DramaticDoors;
-import com.fizzware.dramaticdoors.blocks.ShortDoorBlock;
-import com.fizzware.dramaticdoors.blocks.TallDoorBlock;
+import com.fizzware.dramaticdoors.forge.DDRegistry;
+import com.fizzware.dramaticdoors.forge.blocks.ShortDoorBlock;
+import com.fizzware.dramaticdoors.forge.blocks.TallDoorBlock;
 import net.mehvahdjukaar.every_compat.EveryCompat;
 import net.mehvahdjukaar.every_compat.api.SimpleEntrySet;
 import net.mehvahdjukaar.every_compat.api.SimpleModule;
@@ -13,7 +13,6 @@ import net.minecraft.core.Registry;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
-
 import java.util.List;
 
 public class DramaticDoorsModule extends SimpleModule {
@@ -34,7 +33,7 @@ public class DramaticDoorsModule extends SimpleModule {
                 .addTag(modRes("tall_wooden_doors"), Registry.ITEM_REGISTRY)
                 .addTag(BlockTags.MINEABLE_WITH_AXE, Registry.BLOCK_REGISTRY)
                 .setRenderType(() -> RenderType::cutout)
-                .setTab(() -> DramaticDoors.MAIN_TAB)
+                .setTab(() -> DDRegistry.MAIN_TAB)
                 .copyParentDrop()
                 .defaultRecipe()
                 .build();
@@ -49,7 +48,7 @@ public class DramaticDoorsModule extends SimpleModule {
                 .addTag(modRes("short_wooden_doors"), Registry.ITEM_REGISTRY)
                 .addTag(BlockTags.MINEABLE_WITH_AXE, Registry.BLOCK_REGISTRY)
                 .setRenderType(() -> RenderType::cutout)
-                .setTab(() -> DramaticDoors.MAIN_TAB)
+                .setTab(() -> DDRegistry.MAIN_TAB)
                 .copyParentDrop()
                 .defaultRecipe()
                 .build();
@@ -60,14 +59,21 @@ public class DramaticDoorsModule extends SimpleModule {
     @Override
     public List<String> getAlreadySupportedMods() {
         return List.of(
-                "biomesoplenty", "byg", "prehistoricfauna", "twilightforest", "tflostblocks",
-                "bamboo_blocks", "caverns_and_chasms", "endergetic", "environmental", "upgrade_aquatic",
-                "abundance", "atmospheric", "autumnity", "bayou_blues", "buzzier_bees",
-                "enhanced_mushrooms", "architects_palette", "ars_nouveau", "biomemakeover", "blocksplus",
-                "ceilands", "copperoverhaul", "alloyed", "createdeco", "darkerdepths",
-                "dustrial_decor", "ecologics", "phantasm", "nourished_end", "habitat",
-                "nethers_exoticism", "outer_end", "pokecube", "pokecube_legends", "premium_wood", "quark",
-                "snowyspirit", "supplementaries", "twigs", "undergarden"
+            "abundance", "abundant_atmosphere", "ad_astra",
+            "aether", "alloyed", "architects_palette",
+            "ars_nouveau", "atmospheric", "autumnity",
+            "bamboo_blocks", "bayou_blues", "biomemakeover",
+            "biomesoplenty", "blocksplus", "buzzier_bees",
+            "byg", "caverns_and_chasms", "ceilands",
+            "copperoverhaul", "createdeco", "darkerdepths",
+            "dustrial_decor", "ecologics", "endergetic",
+            "enhanced_mushrooms", "environmental", "habitat",
+            "hexcasting", "nethers_exoticism", "nourished_end",
+            "outer_end", "phantasm", "pokecube",
+            "pokecube_legends", "prehistoricfauna", "premium_wood",
+            "quark", "snowyspirit", "supplementaries",
+            "tflostblocks", "twigs", "twilightforest",
+            "undergarden", "upgrade_aquatic", "windswept"
         );
     }
 }


### PR DESCRIPTION
Updated to [latest 1.19.2](https://www.curseforge.com/minecraft/mc-mods/dramatic-doors/files/4803790) version of Dramatic Doors to fix crash. These same changes could be applied to 1.20.