### PR TITLE
Woodster Chiseled Bookshelf Fix

### DIFF
--- a/forge/src/main/java/net/mehvahdjukaar/every_compat/modules/forge/woodster/WoodsterModule.java
+++ b/forge/src/main/java/net/mehvahdjukaar/every_compat/modules/forge/woodster/WoodsterModule.java
@@ -30,10 +30,10 @@ public class WoodsterModule extends SimpleModule {
         chiseled_books = SimpleEntrySet.builder(WoodType.class, "chiseled_bookshelf",
                         WoodsterBlocks.DARK_OAK_CHISELED_BOOKSHELF, () -> WoodTypeRegistry.OAK_TYPE,
                         w -> new ChiseledBookshelfBlock(Utils.copyPropertySafe(w.planks)))
-                .addTextureM(modRes("block/oak_chiseled_bookshelf_6"),modRes( "block/everycomp_chiseled_bookshelf_6"))
-                .addTexture(modRes("block/oak_chiseled_bookshelf_side"))
-                .addTexture(modRes("block/oak_chiseled_bookshelf_top"))
-                .addTexture(modRes("block/oak_chiseled_bookshelf_0"))
+                .addTextureM(modRes("block/dark_oak_chiseled_bookshelf_6"),modRes( "block/everycomp_chiseled_bookshelf_6"))
+                .addTexture(modRes("block/dark_oak_chiseled_bookshelf_side"))
+                .addTexture(modRes("block/dark_oak_chiseled_bookshelf_top"))
+                .addTexture(modRes("block/dark_oak_chiseled_bookshelf_0"))
                 .addTag(BlockTags.MINEABLE_WITH_AXE, Registries.BLOCK)
                 .setTab(WoodsterTabs.WOODSTER)
                 .copyParentDrop()

--- a/forge/src/main/java/net/mehvahdjukaar/every_compat/modules/forge/woodster/WoodsterModule.java
+++ b/forge/src/main/java/net/mehvahdjukaar/every_compat/modules/forge/woodster/WoodsterModule.java
@@ -28,9 +28,9 @@ public class WoodsterModule extends SimpleModule {
         super(modId, "wdst");
 
         chiseled_books = SimpleEntrySet.builder(WoodType.class, "chiseled_bookshelf",
-                        WoodsterBlocks.DARK_OAK_CHISELED_BOOKSHELF, () -> WoodTypeRegistry.OAK_TYPE,
+                        WoodsterBlocks.DARK_OAK_CHISELED_BOOKSHELF, () -> WoodTypeRegistry.getValue(new ResourceLocation("dark_oak")),
                         w -> new ChiseledBookshelfBlock(Utils.copyPropertySafe(w.planks)))
-                .addTextureM(modRes("block/dark_oak_chiseled_bookshelf_6"),modRes( "block/everycomp_chiseled_bookshelf_6"))
+                .addTextureM(modRes("block/dark_oak_chiseled_bookshelf_6"),modRes("block/everycomp_chiseled_bookshelf_6"))
                 .addTexture(modRes("block/dark_oak_chiseled_bookshelf_side"))
                 .addTexture(modRes("block/dark_oak_chiseled_bookshelf_top"))
                 .addTexture(modRes("block/dark_oak_chiseled_bookshelf_0"))


### PR DESCRIPTION
-Updates Chiseled Bookshelf to use "Dark Oak" fully instead of "Oak" which should fix issue of generated Chiseled Bookshelves not having properly named blockstates & models.