### PR TITLE
UPDATED build.gradle, AbstractSimpleEntrySet & Others

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/every_compat/api/AbstractSimpleEntrySet.java
+++ b/common/src/main/java/net/mehvahdjukaar/every_compat/api/AbstractSimpleEntrySet.java
@@ -186,7 +186,8 @@ public abstract class AbstractSimpleEntrySet<T extends BlockType, B extends Bloc
                 T w = entry.getKey();
                 //skips disabled ones
 
-                if (!WoodConfigs.isEntryEnabled(w, b)) continue;
+                // actually we dont otherwise we get missign texture log spam. TODO: replace models with empty dummy instead
+//                if (!WoodConfigs.isEntryEnabled(w, b)) continue;
 
                 ResourceLocation blockId = Utils.getID(b);
 

--- a/common/src/main/java/net/mehvahdjukaar/every_compat/configs/WoodConfigs.java
+++ b/common/src/main/java/net/mehvahdjukaar/every_compat/configs/WoodConfigs.java
@@ -11,7 +11,7 @@ import net.mehvahdjukaar.moonlight.api.set.leaves.LeavesType;
 import net.mehvahdjukaar.moonlight.api.set.wood.WoodType;
 import net.minecraft.world.level.ItemLike;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;

--- a/common/src/main/java/net/mehvahdjukaar/every_compat/misc/ResourcesUtils.java
+++ b/common/src/main/java/net/mehvahdjukaar/every_compat/misc/ResourcesUtils.java
@@ -29,7 +29,7 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Block;
 import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.*;
 import java.util.function.Consumer;
 

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -55,14 +55,14 @@ dependencies {
     modCompileOnly("curse.maven:another-furniture-610492:4032093")
     modCompileOnly("curse.maven:architects-palette-fabric-487364:3845046")
     modCompileOnly("curse.maven:dramatic-doors-380617:4817180")
-    modImplementation("curse.maven:arrp-463113:3829389")
+    modCompileOnly("curse.maven:arrp-463113:3829389")
     modCompileOnly("curse.maven:camp-chair-531744:3835679")
     modCompileOnly("curse.maven:chipped-456956:4634858")
-    modImplementation("curse.maven:cozy-625281:4171816")
+    modCompileOnly("curse.maven:cozy-625281:4171816")
     modCompileOnly("curse.maven:create-fabric-624165:4597892")
-    modImplementation("curse.maven:decorative-blocks-362528:3941637")
+    modCompileOnly("curse.maven:decorative-blocks-362528:3941637")
     modCompileOnly("curse.maven:exlines-bark-carpets-527296:4062547")
-    modImplementation("curse.maven:farmers-delight-fabric-482834:4111426")
+    modCompileOnly("curse.maven:farmers-delight-fabric-482834:4111426")
     modCompileOnly("curse.maven:furnish-547069:4449619")
     modCompileOnly("curse.maven:friends-and-foes-551364:4429816")
 
@@ -71,7 +71,7 @@ dependencies {
 
     modCompileOnly("curse.maven:macaws-bridges-351725:4599786")
     modCompileOnly("curse.maven:macaws-doors-378646:4649884")
-    modCompileOnly("curse.maven:macaws-fences-and-walls-453925:5045040")
+    modCompileOnly("curse.maven:macaws-fences-and-walls-453925:5121430")
     modCompileOnly("curse.maven:macaws-lights-and-lamps-502372:4618164")
     modCompileOnly("curse.maven:macaws-paths-and-pavings-629153:5054851")
     modCompileOnly("curse.maven:macaws-roofs-352039:4590009")
@@ -79,9 +79,9 @@ dependencies {
     modCompileOnly("curse.maven:macaws-furniture-359540:4726276")
     modCompileOnly("curse.maven:macaws-windows-363569:4750640")
 
-    modImplementation("curse.maven:missing-wilds-622590:3891602")
+    modCompileOnly("curse.maven:missing-wilds-622590:3891602")
     modCompileOnly("curse.maven:the-twilight-forest-227639:4389094")
-    modImplementation("curse.maven:twigs-496913:4531594")
+    modCompileOnly("curse.maven:twigs-496913:4531594")
     modRuntimeOnly("curse.maven:hearth-and-home-849364:4488851")
 
     // =========================================== WORK IN PROGRESS ================================================= \\

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -158,7 +158,7 @@ dependencies {
 
     modCompileOnly("curse.maven:macaws-bridges-351725:4599799")
     modCompileOnly("curse.maven:macaws-doors-378646:4649906")
-    modCompileOnly("curse.maven:macaws-fences-and-walls-453925:5046056")
+    modCompileOnly("curse.maven:macaws-fences-and-walls-453925:5050215")
     modCompileOnly("curse.maven:macaws-furniture-359540:4726294")
     modCompileOnly("curse.maven:macaws-lights-and-lamps-502372:4618179")
     modCompileOnly("curse.maven:macaws-paths-and-pavings-629153:5054877")
@@ -189,7 +189,7 @@ dependencies {
 
 
     // =========================================== WORK IN PROGRESS ================================================= \\
-    modImplementation("curse.maven:handcrafted-538214:4437459")
+    modCompileOnly("curse.maven:handcrafted-538214:4437459")
 
     // ============================================= NOT ADDED YET ================================================== \\
 //    modImplementation("curse.maven:i-like-wood-324164:4463114")


### PR DESCRIPTION
#### UPDATED: 
- build.gradle (FORGE & FABRIC) - updated Macaw's fence to v1.1.1
- AbstractSimpleEntrySet - commented out "IF statement" to stop the spamming log if WoodType or BlockType is disabled
- change the import from Javax to importing JetBrains' Annotation `@Nullable` 