### PR TITLE
Hotfix zh_cn

### DIFF
--- a/common/src/main/resources/assets/everycomp/lang/zh_cn.json
+++ b/common/src/main/resources/assets/everycomp/lang/zh_cn.json
@@ -1710,7 +1710,7 @@
   "wood_type.productivetrees.yellow_meranti": "黄桉木",
   "wood_type.productivetrees.yew": "红豆杉木",
   "wood_type.productivetrees.zebrano": "斑马木",
-  "leaves_type.productivetrees.pollinated": "",
+  "leaves_type.productivetrees.pollinated": "授粉的",
   "leaves_type.productivetrees.alder": "黑桤",
   "leaves_type.productivetrees.allspice": "多香果",
   "leaves_type.productivetrees.almond": "扁桃",


### PR DESCRIPTION
Fixed `pollinated` leaves type in `productivetrees` not being translated