### PR TITLE
Added Table Top Craft Compatibility

### DIFF
--- a/common/src/main/resources/assets/everycomp/lang/en_us.json
+++ b/common/src/main/resources/assets/everycomp/lang/en_us.json
@@ -942,5 +942,9 @@
 
   "block_type.tropicraft.boardwalk": "%s Boardwalk",
 
-  "item_type.justaraftmod.raft": "%s Log Raft"
+  "item_type.justaraftmod.raft": "%s Log Raft",
+
+  "block_type.table_top_craft.chess": "%s Chess Board",
+  "block_type.table_top_craft.chess_timer": "%s Chess Timer",
+  "block_type.table_top_craft.connect_four": "%s Connect Four"
 }

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -115,6 +115,7 @@ dependencies {
     modCompileOnly("curse.maven:villagersplus-fabric-809542:4996993")
     modCompileOnly("maven.modrinth:wilder-wild:2.4-mc1.20.1")
     modCompileOnly("curse.maven:wooden-hoppers-406021:4796143")
+    modCompileOnly("curse.maven:table-top-craft-fabric-729535:5319819") //RLM: exp4j
 
     modCompileOnly("curse.maven:regions-unexplored-659110:5151837")
 

--- a/fabric/src/main/java/net/mehvahdjukaar/every_compat/fabric/EveryCompatFabric.java
+++ b/fabric/src/main/java/net/mehvahdjukaar/every_compat/fabric/EveryCompatFabric.java
@@ -22,6 +22,7 @@ import net.mehvahdjukaar.every_compat.modules.fabric.mcaw.*;
 import net.mehvahdjukaar.every_compat.modules.fabric.lieonlion.MoreCraftingTablesModule;
 import net.mehvahdjukaar.every_compat.modules.fabric.red_bits.RedBitsModule;
 import net.mehvahdjukaar.every_compat.modules.fabric.regions_unexplored.RegionsUnexploredModule;
+import net.mehvahdjukaar.every_compat.modules.fabric.table_top_craft.TableTopCraftModule;
 import net.mehvahdjukaar.every_compat.modules.fabric.variants.VariantVanillaBlocksModule;
 import net.mehvahdjukaar.every_compat.modules.fabric.wilder_wild.WilderWildModule;
 import net.mehvahdjukaar.every_compat.modules.fabric.wooden_hoppers.WoodenHoppersModule;
@@ -65,6 +66,7 @@ public class EveryCompatFabric extends EveryCompat implements ModInitializer {
         addModule("variantvanillablocks", () -> VariantVanillaBlocksModule::new);
         addModule("wilderwild", () -> WilderWildModule::new);
         addModule("woodenhoppers", () -> WoodenHoppersModule::new);
+        addModule("table_top_craft", () -> TableTopCraftModule::new);
 
 // ============================================== DISABLED FOR A REASON ============================================= \\
 //        addModule("twilightforest", () -> TwilightForestModule::new); // Not available

--- a/fabric/src/main/java/net/mehvahdjukaar/every_compat/modules/fabric/table_top_craft/TableTopCraftModule.java
+++ b/fabric/src/main/java/net/mehvahdjukaar/every_compat/modules/fabric/table_top_craft/TableTopCraftModule.java
@@ -1,0 +1,57 @@
+package net.mehvahdjukaar.every_compat.modules.fabric.table_top_craft;
+
+import andrews.table_top_craft.objects.blocks.ChessBlock;
+import andrews.table_top_craft.objects.blocks.ChessTimerBlock;
+import andrews.table_top_craft.objects.blocks.ConnectFourBlock;
+import andrews.table_top_craft.registry.TTCBlockEntities;
+import net.mehvahdjukaar.every_compat.api.SimpleEntrySet;
+import net.mehvahdjukaar.every_compat.api.SimpleModule;
+import net.mehvahdjukaar.moonlight.api.set.wood.WoodType;
+import net.mehvahdjukaar.moonlight.api.set.wood.WoodTypeRegistry;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.world.level.block.Block;
+
+public class TableTopCraftModule extends SimpleModule {
+
+    public final SimpleEntrySet<WoodType, Block> chessBoards;
+    public final SimpleEntrySet<WoodType, Block> chessTimers;
+    public final SimpleEntrySet<WoodType, Block> connectFours;
+
+    public TableTopCraftModule(String modId) {
+        super(modId, "ttc");
+
+        chessBoards = SimpleEntrySet.builder(WoodType.class, "chess",
+                        getModBlock("oak_chess"), () -> WoodTypeRegistry.OAK_TYPE,
+                        w -> new ChessBlock(w.getColor(), w.getSound()))
+                .addTile(() -> TTCBlockEntities.CHESS)
+                .addTag(modRes("chess_boards"), Registries.ITEM)
+                .addTag(BlockTags.MINEABLE_WITH_AXE, Registries.BLOCK)
+                .setTabKey(modRes("tab"))
+                .defaultRecipe()
+                .build();
+        this.addEntry(chessBoards);
+
+        chessTimers = SimpleEntrySet.builder(WoodType.class, "chess_timer",
+                        getModBlock("oak_chess_timer"), () -> WoodTypeRegistry.OAK_TYPE,
+                        w -> new ChessTimerBlock(w.getColor(), w.getSound()))
+                .addTile(() -> TTCBlockEntities.CHESS_TIMER)
+                .addTag(modRes("chess_timers"), Registries.ITEM)
+                .addTag(BlockTags.MINEABLE_WITH_AXE, Registries.BLOCK)
+                .setTabKey(modRes("tab"))
+                .defaultRecipe()
+                .build();
+        this.addEntry(chessTimers);
+
+        connectFours = SimpleEntrySet.builder(WoodType.class, "connect_four",
+                        getModBlock("oak_connect_four"), () -> WoodTypeRegistry.OAK_TYPE,
+                        w -> new ConnectFourBlock(w.getColor(), w.getSound()))
+                .addTile(() -> TTCBlockEntities.CONNECT_FOUR)
+                .addTag(modRes("connect_four"), Registries.ITEM)
+                .addTag(BlockTags.MINEABLE_WITH_AXE, Registries.BLOCK)
+                .setTabKey(modRes("tab"))
+                .defaultRecipe()
+                .build();
+        this.addEntry(connectFours);
+    }
+}

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -220,6 +220,7 @@ dependencies {
     modCompileOnly("curse.maven:woodworks-543610:5228779")
     modCompileOnly("curse.maven:workshop-for-handsome-adventurer-875843:4692349")
     modCompileOnly("curse.maven:xercamod-341575:4667995")
+    modCompileOnly("curse.maven:table-top-craft-467136:5318681")
 
     modCompileOnly("curse.maven:regions-unexplored-659110:5151869")
 

--- a/forge/src/main/java/net/mehvahdjukaar/every_compat/forge/EveryCompatForge.java
+++ b/forge/src/main/java/net/mehvahdjukaar/every_compat/forge/EveryCompatForge.java
@@ -37,6 +37,7 @@ import net.mehvahdjukaar.every_compat.modules.forge.premium_wood.PremiumWoodModu
 import net.mehvahdjukaar.every_compat.modules.forge.redeco.ReDecoModule;
 import net.mehvahdjukaar.every_compat.modules.forge.regions_unexplored.RegionsUnexploredModule;
 import net.mehvahdjukaar.every_compat.modules.forge.storagedrawers.StorageDrawersModule;
+import net.mehvahdjukaar.every_compat.modules.forge.table_top_craft.TableTopCraftModule;
 import net.mehvahdjukaar.every_compat.modules.forge.timber_frames.TimberFramesModule;
 import net.mehvahdjukaar.every_compat.modules.forge.tropicraft.TropicraftModule;
 import net.mehvahdjukaar.every_compat.modules.forge.twilightforest.TwilightForestModule;
@@ -122,6 +123,7 @@ public class EveryCompatForge extends EveryCompat {
             addModule("dramaticdoors", () -> DramaticDoorsMacawModule::new);
         }
         addModule("lolmct", () -> MoreCraftingTablesModule::new);
+        addModule("table_top_craft", () -> TableTopCraftModule::new);
 
         // ========================================= Macaw's ======================================================== \\
         addModule("mcwbridges", () -> MacawBridgesModule::new);

--- a/forge/src/main/java/net/mehvahdjukaar/every_compat/modules/forge/table_top_craft/TableTopCraftModule.java
+++ b/forge/src/main/java/net/mehvahdjukaar/every_compat/modules/forge/table_top_craft/TableTopCraftModule.java
@@ -1,0 +1,57 @@
+package net.mehvahdjukaar.every_compat.modules.forge.table_top_craft;
+
+import andrews.table_top_craft.objects.blocks.ChessBlock;
+import andrews.table_top_craft.objects.blocks.ChessTimerBlock;
+import andrews.table_top_craft.objects.blocks.ConnectFourBlock;
+import andrews.table_top_craft.registry.TTCBlockEntities;
+import net.mehvahdjukaar.every_compat.api.SimpleEntrySet;
+import net.mehvahdjukaar.every_compat.api.SimpleModule;
+import net.mehvahdjukaar.moonlight.api.set.wood.WoodType;
+import net.mehvahdjukaar.moonlight.api.set.wood.WoodTypeRegistry;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.world.level.block.Block;
+
+public class TableTopCraftModule extends SimpleModule {
+
+    public final SimpleEntrySet<WoodType, Block> chessBoards;
+    public final SimpleEntrySet<WoodType, Block> chessTimers;
+    public final SimpleEntrySet<WoodType, Block> connectFours;
+
+    public TableTopCraftModule(String modId) {
+        super(modId, "ttc");
+
+        chessBoards = SimpleEntrySet.builder(WoodType.class, "chess",
+                        getModBlock("oak_chess"), () -> WoodTypeRegistry.OAK_TYPE,
+                        w -> new ChessBlock(w.getColor(), w.getSound()))
+                .addTile(TTCBlockEntities.CHESS)
+                .addTag(modRes("chess_boards"), Registries.ITEM)
+                .addTag(BlockTags.MINEABLE_WITH_AXE, Registries.BLOCK)
+                .setTabKey(modRes("tab"))
+                .defaultRecipe()
+                .build();
+        this.addEntry(chessBoards);
+
+        chessTimers = SimpleEntrySet.builder(WoodType.class, "chess_timer",
+                        getModBlock("oak_chess_timer"), () -> WoodTypeRegistry.OAK_TYPE,
+                        w -> new ChessTimerBlock(w.getColor(), w.getSound()))
+                .addTile(TTCBlockEntities.CHESS_TIMER)
+                .addTag(modRes("chess_timers"), Registries.ITEM)
+                .addTag(BlockTags.MINEABLE_WITH_AXE, Registries.BLOCK)
+                .setTabKey(modRes("tab"))
+                .defaultRecipe()
+                .build();
+        this.addEntry(chessTimers);
+
+        connectFours = SimpleEntrySet.builder(WoodType.class, "connect_four",
+                        getModBlock("oak_connect_four"), () -> WoodTypeRegistry.OAK_TYPE,
+                        w -> new ConnectFourBlock(w.getColor(), w.getSound()))
+                .addTile(TTCBlockEntities.CONNECT_FOUR)
+                .addTag(modRes("connect_four"), Registries.ITEM)
+                .addTag(BlockTags.MINEABLE_WITH_AXE, Registries.BLOCK)
+                .setTabKey(modRes("tab"))
+                .defaultRecipe()
+                .build();
+        this.addEntry(connectFours);
+    }
+}


### PR DESCRIPTION
Hey, I'm a fellow Mod developer, and recently it was brought to my attention that there is a [Table Top Craft Request](https://github.com/MehVahdJukaar/WoodGood/issues/422) for your Mod.
Sadly it appears it was miss labelled (probably based on the fabric page and not the forge one) and got `x > 10.000` when the Mod actually has over 1.7mil downloads, so I think it should be `x > 1mil`.

So as the developer of **Table Top Craft** I decided to take you up on your offer:
![image](https://github.com/user-attachments/assets/aabd3cb1-6d3e-4ad5-bac7-b1f8cbc75918)
And to help speed implementation up 😄 

I tried to copy your code style as closely as I could, but I was unfamiliar with the code so it may not be perfect. If you see any big errors or mistakes, please let me know!

Additionally I want to point out that TTC uses a library called "exp4j", I included it in the Mod, but I wasn't 100% sure how you would deal with this, so for now I left a comment in the fabric build gradle. (`//RLM: exp4j`). If this is not what I should have done let me know so I can do it properly in the future!

Lastly I want to thank you for this great project, it was pretty easy to use once I understood the setup, and the way one can easily add support for all wood types is ingenious!
If you think this **PR** is good and it gets merged, I will make 2 more **PR**s for 1.19 and 1.18!

(I tested the code on both fabric/forge and both IDE/Production)