### PR TITLE
Table Top Craft Compatibility for 1.19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,7 @@ subprojects {
                         optionalDependency("missing-wilds")
                         optionalDependency("red-bits")
                         optionalDependency("refurbished-furniture")
+                        optionalDependency("table-top-craft-fabric")
                         optionalDependency("the-twilight-forest")
                         optionalDependency("twigs")
                     }
@@ -151,6 +152,7 @@ subprojects {
                         optionalDependency("rechiseled")
                         optionalDependency("refurbished-furniture")
                         optionalDependency("storage-drawers")
+                        optionalDependency("table-top-craft")
                         optionalDependency("the-twilight-forest")
                         optionalDependency("twigs")
                         optionalDependency("valhelsia-structures")

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     modCompileOnly("curse.maven:the-twilight-forest-227639:4389094")
     modCompileOnly("curse.maven:twigs-496913:4533061")
     modCompileOnly("curse.maven:refurbished-furniture-897116:5651930")
+    modCompileOnly("curse.maven:table-top-craft-fabric-729535:5694015")
 
 //    modCompileOnly("curse.maven:missing-wilds-622590:3891602")
 

--- a/common/src/main/java/net/mehvahdjukaar/every_compat/EveryCompat.java
+++ b/common/src/main/java/net/mehvahdjukaar/every_compat/EveryCompat.java
@@ -19,6 +19,7 @@ import net.mehvahdjukaar.every_compat.modules.friendsandfoes.FriendsAndFoesModul
 import net.mehvahdjukaar.every_compat.modules.furnish.FurnishModule;
 import net.mehvahdjukaar.every_compat.modules.handcrafted.HandcraftedModule;
 import net.mehvahdjukaar.every_compat.modules.hearth_and_home.HearthAndHomeModule;
+import net.mehvahdjukaar.every_compat.modules.table_top_craft.TableTopCraftModule;
 import net.mehvahdjukaar.every_compat.modules.twigs.TwigsModule;
 // LIB
 import net.mehvahdjukaar.moonlight.api.client.TextureCache;
@@ -130,6 +131,7 @@ public abstract class EveryCompat {
         addModule("furnish", () -> FurnishModule::new);
         addModule( "hnh" , () -> HearthAndHomeModule::new);
         addModule("twigs", () -> TwigsModule::new);
+        addModule("table_top_craft", () -> TableTopCraftModule::new);
 
         // =========================================== WORK IN PROGRESS ============================================  \\
         addModule("handcrafted", () -> HandcraftedModule::new);

--- a/common/src/main/java/net/mehvahdjukaar/every_compat/modules/table_top_craft/TableTopCraftModule.java
+++ b/common/src/main/java/net/mehvahdjukaar/every_compat/modules/table_top_craft/TableTopCraftModule.java
@@ -1,0 +1,74 @@
+package net.mehvahdjukaar.every_compat.modules.table_top_craft;
+
+import andrews.table_top_craft.TableTopCraft;
+import andrews.table_top_craft.objects.blocks.ChessBlock;
+import andrews.table_top_craft.objects.blocks.ChessTimerBlock;
+import andrews.table_top_craft.objects.blocks.ConnectFourBlock;
+import net.mehvahdjukaar.every_compat.api.SimpleEntrySet;
+import net.mehvahdjukaar.every_compat.api.SimpleModule;
+import net.mehvahdjukaar.moonlight.api.set.BlockType;
+import net.mehvahdjukaar.moonlight.api.set.wood.WoodType;
+import net.mehvahdjukaar.moonlight.api.set.wood.WoodTypeRegistry;
+import net.minecraft.core.Registry;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.world.level.ItemLike;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.SoundType;
+
+//SUPPORT: FORGE-v3.1.0+ | FABRIC-v2.1.0+
+public class TableTopCraftModule extends SimpleModule {
+    public final SimpleEntrySet<WoodType, Block> chessBoards;
+    public final SimpleEntrySet<WoodType, Block> chessTimers;
+    public final SimpleEntrySet<WoodType, Block> connectFours;
+
+    public TableTopCraftModule(String modId) {
+        super(modId, "ttc");
+        // This is fine up to 1.19.2, but after that tab registration changed so the field no longer exists!
+        var tab = TableTopCraft.TABLE_TOP_CRAFT_GROUP;
+
+        chessBoards = SimpleEntrySet.builder(WoodType.class, "chess",
+                        () -> getModBlock("oak_chess"), () -> WoodTypeRegistry.OAK_TYPE,
+                        w -> new ChessBlock(w.material, getSound(w)))
+                .addTile(() -> getModTile("chess"))
+                .addTag(modRes("chess_boards"), Registry.ITEM_REGISTRY)
+                .addTag(BlockTags.MINEABLE_WITH_AXE, Registry.BLOCK_REGISTRY)
+                .setTab(() -> tab)
+                .defaultRecipe()
+                .build();
+        this.addEntry(chessBoards);
+
+        chessTimers = SimpleEntrySet.builder(WoodType.class, "chess_timer",
+                        () -> getModBlock("oak_chess_timer"), () -> WoodTypeRegistry.OAK_TYPE,
+                        w -> new ChessTimerBlock(w.material, getSound(w)))
+                .addTile(() -> getModTile("chess_timer"))
+                .addTag(modRes("chess_timers"), Registry.ITEM_REGISTRY)
+                .addTag(BlockTags.MINEABLE_WITH_AXE, Registry.BLOCK_REGISTRY)
+                .setTab(() -> tab)
+                .defaultRecipe()
+                .build();
+        this.addEntry(chessTimers);
+
+        connectFours = SimpleEntrySet.builder(WoodType.class, "connect_four",
+                        () -> getModBlock("oak_connect_four"), () -> WoodTypeRegistry.OAK_TYPE,
+                        w -> new ConnectFourBlock(w.material, getSound(w)))
+                .addTile(() -> getModTile("connect_four"))
+                .addTag(modRes("connect_four"), Registry.ITEM_REGISTRY)
+                .addTag(BlockTags.MINEABLE_WITH_AXE, Registry.BLOCK_REGISTRY)
+                .setTab(() -> tab)
+                .defaultRecipe()
+                .build();
+        this.addEntry(connectFours);
+    }
+
+    /*
+     * We need the sound type for the constructors, this code
+     * retrieves the proper SoundType from the given BlockType.
+     * (This method already exists in BlockType, in 1.20.1+)
+     */
+    private SoundType getSound(BlockType type) {
+        ItemLike itemLike = type.mainChild();
+        if (itemLike instanceof Block block)
+            return block.getSoundType(block.defaultBlockState());
+        return SoundType.STONE;
+    }
+}

--- a/common/src/main/resources/assets/everycomp/lang/en_us.json
+++ b/common/src/main/resources/assets/everycomp/lang/en_us.json
@@ -820,6 +820,9 @@
   "block_type.absentbydesign.fence_log": "%s Log Fence",
   "block_type.absentbydesign.wall_stripped_log": "Stripped %s Wall",
   "block_type.absentbydesign.wall_log": "%s Wood Wall",
-  "block_type.absentbydesign.wall_planks": "%s Wall"
-}
+  "block_type.absentbydesign.wall_planks": "%s Wall",
 
+  "block_type.table_top_craft.chess": "%s Chess Board",
+  "block_type.table_top_craft.chess_timer": "%s Chess Timer",
+  "block_type.table_top_craft.connect_four": "%s Connect Four"
+}


### PR DESCRIPTION
- A back port of the `TableTopCraftModule`.
- Tested on `forge` in IDE and `forge`/`fabric` in Production. (Had some issues getting `fabric` to run in IDE)

As always if something doesn't look right let me know.
Also, I added a `getSound` method inside the Module, since the `net.mehvahdjukaar.moonlight.api.set.BlockType` class does not seem to have one in `1.19`. Should this change we could probably swap it out.