### PR TITLE
Table Top Craft Compatibility for 1.18

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -205,6 +205,7 @@ dependencies {
     compileOnly fg.deobf("curse.maven:woodworks-543610:4396956")
     compileOnly fg.deobf("curse.maven:xercamod-341575:4318574")
     compileOnly fg.deobf("curse.maven:chipped-456956:4293291")
+    compileOnly fg.deobf("curse.maven:table-top-craft-467136:5699783")
 
         // LOCAL
     compileOnly fg.deobf(getModVersion("ironagefurniture-1.18.2-0.2.0.10.jar"))
@@ -342,6 +343,7 @@ publishMods {
         optional("mrcrayfish-furniture-mod")
         optional("project-brazier")
         optional("quark")
+        optional("table-top-craft")
         optional("the-twilight-forest")
         optional("the-graveyard-forge")
         optional("twigs")

--- a/src/main/java/net/mehvahdjukaar/every_compat/WoodGood.java
+++ b/src/main/java/net/mehvahdjukaar/every_compat/WoodGood.java
@@ -29,6 +29,7 @@ import net.mehvahdjukaar.every_compat.modules.missing_wilds.MissingWildModule;
 import net.mehvahdjukaar.every_compat.modules.mrcrayfish_furniture.MrCrayfishFurnitureModule;
 import net.mehvahdjukaar.every_compat.modules.quark.QuarkModule;
 import net.mehvahdjukaar.every_compat.modules.stylish_stiles.StylishStilesModule;
+import net.mehvahdjukaar.every_compat.modules.table_top_craft.TableTopCraftModule;
 import net.mehvahdjukaar.every_compat.modules.twigs.TwigsModule;
 import net.mehvahdjukaar.every_compat.modules.twilightforest.TwilightForestModule;
 import net.mehvahdjukaar.every_compat.modules.valhelsia_structures.ValhelsiaStructuresModule;
@@ -171,6 +172,7 @@ public class WoodGood {
         addModule("xercamod", () -> XercaModule::new);
         addModule("decorative_blocks", () -> DecorativeBlocksModule::new);
         addModule("chipped", () -> ChippedModule::new);
+        addModule("table_top_craft", () -> TableTopCraftModule::new);
 
         // =========================================== CURRENTLY WIP ================================================ \\
 

--- a/src/main/java/net/mehvahdjukaar/every_compat/modules/table_top_craft/CompatChessBlock.java
+++ b/src/main/java/net/mehvahdjukaar/every_compat/modules/table_top_craft/CompatChessBlock.java
@@ -1,0 +1,20 @@
+package net.mehvahdjukaar.every_compat.modules.table_top_craft;
+
+import andrews.table_top_craft.objects.blocks.ChessBlock;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.SoundType;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.Material;
+
+public class CompatChessBlock extends ChessBlock {
+
+    public CompatChessBlock(Material material, SoundType soundType) {
+        super(material, soundType);
+    }
+
+    @Override
+    public BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
+        return new CompatChessBlockTile(pos, state);
+    }
+}

--- a/src/main/java/net/mehvahdjukaar/every_compat/modules/table_top_craft/CompatChessBlockTile.java
+++ b/src/main/java/net/mehvahdjukaar/every_compat/modules/table_top_craft/CompatChessBlockTile.java
@@ -1,0 +1,18 @@
+package net.mehvahdjukaar.every_compat.modules.table_top_craft;
+
+import andrews.table_top_craft.tile_entities.ChessTileEntity;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
+
+public class CompatChessBlockTile extends ChessTileEntity {
+
+    public CompatChessBlockTile(BlockPos pos, BlockState state) {
+        super(pos, state);
+    }
+
+    @Override
+    public BlockEntityType<?> getType() {
+        return TableTopCraftModule.CHESS_TILE;
+    }
+}

--- a/src/main/java/net/mehvahdjukaar/every_compat/modules/table_top_craft/TableTopCraftModule.java
+++ b/src/main/java/net/mehvahdjukaar/every_compat/modules/table_top_craft/TableTopCraftModule.java
@@ -1,0 +1,65 @@
+package net.mehvahdjukaar.every_compat.modules.table_top_craft;
+
+import andrews.table_top_craft.TableTopCraft;
+import andrews.table_top_craft.tile_entities.ChessTileEntity;
+import andrews.table_top_craft.tile_entities.render.ChessTileEntityRenderer;
+import net.mehvahdjukaar.every_compat.api.SimpleEntrySet;
+import net.mehvahdjukaar.every_compat.api.SimpleModule;
+import net.mehvahdjukaar.selene.block_set.BlockType;
+import net.mehvahdjukaar.selene.block_set.wood.WoodType;
+import net.minecraft.core.Registry;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.world.level.ItemLike;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.SoundType;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraftforge.client.event.EntityRenderersEvent;
+import net.minecraftforge.registries.IForgeRegistry;
+
+//SUPPORT: FORGE-v2.2.0+
+public class TableTopCraftModule extends SimpleModule {
+    // Blocks
+    public final SimpleEntrySet<WoodType, Block> CHESS_BOARDS;
+    // Block Entity Types
+    public static BlockEntityType<? extends ChessTileEntity> CHESS_TILE;
+
+    public TableTopCraftModule(String modId) {
+        super(modId, "ttc");
+
+        CHESS_BOARDS = SimpleEntrySet.builder(WoodType.class, "chess",
+                        () -> getModBlock("oak_chess"), () -> WoodType.OAK_WOOD_TYPE,
+                        w -> new CompatChessBlock(w.getMaterial(), getSound(w)))
+                .addTile(CompatChessBlockTile::new)
+                .addTag(modRes("chess_boards"), Registry.ITEM_REGISTRY)
+                .addTag(BlockTags.MINEABLE_WITH_AXE, Registry.BLOCK_REGISTRY)
+                .setTab(() -> TableTopCraft.TABLE_TOP_CRAFT_GROUP)
+                .defaultRecipe()
+                .build();
+        this.addEntry(CHESS_BOARDS);
+    }
+
+    /*
+     * We need the sound type for the constructors, this code
+     * retrieves the proper SoundType from the given BlockType.
+     * (This method already exists in BlockType, in 1.20.1+)
+     */
+    @SuppressWarnings("deprecation")
+    private SoundType getSound(BlockType type) {
+        ItemLike itemLike = type.mainChild();
+        if (itemLike instanceof Block block)
+            return block.getSoundType(block.defaultBlockState());
+        return SoundType.STONE;
+    }
+
+    @Override
+    public void registerTiles(IForgeRegistry<BlockEntityType<?>> registry) {
+        super.registerTiles(registry);
+        CHESS_TILE = (BlockEntityType<? extends ChessTileEntity>) CHESS_BOARDS.getTileHolder().tile;
+    }
+
+    @Override
+    public void registerEntityRenderers(EntityRenderersEvent.RegisterRenderers event) {
+        super.registerEntityRenderers(event);
+        event.registerBlockEntityRenderer(CHESS_TILE, ChessTileEntityRenderer::new);
+    }
+}

--- a/src/main/resources/assets/everycomp/lang/en_us.json
+++ b/src/main/resources/assets/everycomp/lang/en_us.json
@@ -613,5 +613,7 @@
   "block_type.chipped.stripped_log_8": "Stripped %s Log",
   "block_type.chipped.stripped_log_9": "Stripped %s Log",
   "block_type.chipped.stripped_log_10": "Stripped %s Log",
-  "block_type.chipped.stripped_log_11": "Stripped %s Log"
+  "block_type.chipped.stripped_log_11": "Stripped %s Log",
+
+  "block_type.table_top_craft.chess": "%s Chess Board"
 }


### PR DESCRIPTION
- Back port of the `TableTopCraftModule` for `1.18`.

I tested it on `forge` (duh), both in the `IDE` and in `Production`.

Note: you might want to upload a `.gitignore`, I assume you have them locally but never pushed them to github.