### PR TITLE
Fix EC's FaF beehives not getting recognized as villager workstation.

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/every_compat/modules/friendsandfoes/FriendsAndFoesModule.java
+++ b/common/src/main/java/net/mehvahdjukaar/every_compat/modules/friendsandfoes/FriendsAndFoesModule.java
@@ -60,7 +60,7 @@ public class FriendsAndFoesModule extends SimpleModule {
     protected final ResourceLocation POI_ID = EveryCompat.res("faf_beehive");
 
     private final Supplier<PoiType> compatBeeHivePOI = RegHelper.registerPOI(POI_ID,
-            () -> new PoiType(getBeehives(), 0, 1));
+            () -> new PoiType(getBeehives(), 1, 1));
 
     private Set<BlockState> getBeehives() {
         var set = new ImmutableSet.Builder<BlockState>();
@@ -72,10 +72,17 @@ public class FriendsAndFoesModule extends SimpleModule {
     public void addDynamicServerResources(ServerDynamicResourcesHandler handler, ResourceManager manager) {
         super.addDynamicServerResources(handler, manager);
 
-        SimpleTagBuilder tb = SimpleTagBuilder.of(PoiTypeTags.BEE_HOME);
+        SimpleTagBuilder bee_home = SimpleTagBuilder.of(PoiTypeTags.BEE_HOME);
         //Bee.BeeGoToHiveGoal
-        tb.add(POI_ID);
+        bee_home.add(POI_ID);
 
-        handler.dynamicPack.addTag(tb, Registries.POINT_OF_INTEREST_TYPE);
+        handler.dynamicPack.addTag(bee_home, Registries.POINT_OF_INTEREST_TYPE);
+
+        SimpleTagBuilder acquirable_job_site = SimpleTagBuilder.of(PoiTypeTags.ACQUIRABLE_JOB_SITE);
+        // Villager.POI_MEMORIES map entry: MemoryModuleType.POTENTIAL_JOB_SITE,
+        //                                  (villager, holder) -> VillagerProfession.ALL_ACQUIRABLE_JOBS.test(holder),
+        acquirable_job_site.add(POI_ID);
+
+        handler.dynamicPack.addTag(acquirable_job_site, Registries.POINT_OF_INTEREST_TYPE);
     }
 }


### PR DESCRIPTION
Fixes #406 for 1.20.1, porting should be trivial.

Since the 3.0.0 version (1.19.2+), Friends and Foes uses the bee_home poi tag instead of hardcoding their specific poi types for the beekeeper, (https://github.com/Faboslav/friends-and-foes/blob/7addad56268dfb69b7ffac7a3d10c5397ea40f8a/common/src/main/java/com/faboslav/friendsandfoes/common/init/FriendsAndFoesVillagerProfessions.java#L23) but that still doesn't actually work for EveryComp's beehives. The acquirable_job_site poi tag is missing from the Everycomp poi (villagers won't check it).
That's *still* not enough actually.

There's an additional mixin that reveals why:
https://github.com/Faboslav/friends-and-foes/blob/1.20.1/common/src/main/java/com/faboslav/friendsandfoes/common/mixin/PointOfInterestTypesMixin.java sets the bee_hive poi entity limit to 1 (from 0) as villagers won't be able to claim the workstation otherwise. 

The Everycomp poi currently had a limit of 0 entities.