### PR TITLE
Update zh_cn for 1.21

### DIFF
--- a/common/src/main/resources/assets/everycomp/lang/zh_cn.json
+++ b/common/src/main/resources/assets/everycomp/lang/zh_cn.json
@@ -214,7 +214,7 @@
   "block_type.dramaticdoors.tall_macaw_swamp_door": "高%s沼泽风格门",
   "block_type.dramaticdoors.tall_macaw_tropical_door": "高%s热带风格门",
 
-  "block_type.farmersdelight.cabinet": "%s厨柜",
+  "block_type.farmersdelight.cabinet": "%s橱柜",
 
   "block_type.friendsandfoes.beehive": "%s蜂箱",
 
@@ -598,6 +598,9 @@
   "block_type.woodworks.chest": "%s箱子",
   "block_type.woodworks.trapped_chest": "%s陷阱箱",
 
+  "item_type.boatload.furnace_boat": "%s动力船",
+  "item_type.boatload.large_boat": "%s大型船",
+
   "block_type.woodster.chiseled_bookshelf": "%s雕纹书架",
   "block_type.woodster.ladder": "%s梯子",
 
@@ -619,9 +622,6 @@
 
   "item_type.buildersdelight.furniture_kit": "%s家具组件",
   "tooltip.everycomp.buildersdelight.furniture_kit": "放入切石机以制作家具",
-
-  "item_type.boatload.furnace_boat": "%s动力船",
-  "item_type.boatload.large_boat": "%s大型船",
 
   "block_type.buildersdelight.chair_1": "%s座椅",
   "tooltip.everycomp.buildersdelight.chair_1": "椅子",
@@ -881,5 +881,30 @@
 
   "block_type.table_top_craft.chess": "%s棋盘",
   "block_type.table_top_craft.chess_timer": "%s棋钟",
-  "block_type.table_top_craft.connect_four": "%s四子棋"
+  "block_type.table_top_craft.connect_four": "%s四子棋",
+
+
+
+
+
+  "everycomp.configuration.general": "通用",
+
+  "everycomp.configuration.creative_tab": "创造标签页",
+  "everycomp.configuration.assets_depend_on_loaded_packs": "根据加载的资源包生成资源",
+  "everycomp.configuration.save_debug_resources": "保存调试资源",
+  "everycomp.configuration.mod_version_check_packet": "模组版本检查包",
+  "everycomp.configuration.debug_packet": "调试包",
+
+  "everycomp.configuration.tooltips": "提示文本",
+
+  "everycomp.configuration.mod_origin_enabled": "启用来源模组",
+  "everycomp.configuration.block_type_enabled": "启用方块种类",
+  "everycomp.configuration.show_on_advanced_tooltips": "仅在启用高级提示框时显示",
+
+
+
+  "everycomp.configuration.types": "材料种类",
+  "everycomp.configuration.entries": "制品种类",
+  "everycomp.configuration.wood_type": "木材种类",
+  "everycomp.configuration.leaves_type": "树叶种类"
 }


### PR DESCRIPTION
The configuration keys for each `wood_type`, `leaves_type`, `block_type` consist of one key for their origin mod, and one for actual name. Those weren't given in this PR.