### PR TITLE
Fix beautify lattices from EC not being climbable

### DIFF
--- a/fabric/src/main/java/net/mehvahdjukaar/every_compat/modules/fabric/beautify_decorate/BeautifyRefabricatedModule.java
+++ b/fabric/src/main/java/net/mehvahdjukaar/every_compat/modules/fabric/beautify_decorate/BeautifyRefabricatedModule.java
@@ -38,6 +38,7 @@ public class BeautifyRefabricatedModule extends SimpleModule {
                 )
                 //TEXTURES: logs
                 .addTag(BlockTags.MINEABLE_WITH_AXE, Registries.BLOCK)
+                .addTag(BlockTags.CLIMBABLE, Registries.BLOCK)
                 .defaultRecipe()
                 .setTabKey(tab)
                 //REASON: take a look at their //TEXTURES, you'll see why.

--- a/forge/src/main/java/net/mehvahdjukaar/every_compat/modules/forge/beautify_decorate/BeautifyDecorateModule.java
+++ b/forge/src/main/java/net/mehvahdjukaar/every_compat/modules/forge/beautify_decorate/BeautifyDecorateModule.java
@@ -34,6 +34,7 @@ public class BeautifyDecorateModule extends SimpleModule {
                         )
                 )
                 .addTag(BlockTags.MINEABLE_WITH_AXE, Registries.BLOCK)
+                .addTag(BlockTags.CLIMBABLE, Registries.BLOCK)
                 .defaultRecipe()
                 .setTabKey(tab)
                 .build();


### PR DESCRIPTION
Beautify's lattices are climbable, but on the Forge side they hardcode them to only the ones from the mod, using super otherwise, which checks for the `minecraft:climbable` tag.
https://github.com/Pandarix/Beautify/blob/4e1224098f61e745a90fa0533d0af3ae0f799eb0/src/main/java/com/github/Pandarix/beautify/common/block/OakTrellis.java#L90-L98
On Fabric the isLadder method doesn't exist (it's added by Forge) so the lattices from the base mod already had the climbable tag: 
https://github.com/Suel-ki/Beautify-Refabricated/blob/1.20.1/src/main/resources/data/minecraft/tags/blocks/climbable.json
This PR just adds that tag to all lattices on both Forge and Fabric.

Should be trivial to port this to 1.18.2, 1.19.2 and 1.21.1 for which beautify also exists and has EC support.
