### PR TITLE
Update Farmer's Delight cabinet tags

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/every_compat/modules/farmersdelight/FarmersDelightModule.java
+++ b/common/src/main/java/net/mehvahdjukaar/every_compat/modules/farmersdelight/FarmersDelightModule.java
@@ -40,13 +40,11 @@ public class FarmersDelightModule extends SimpleModule {
                         w -> new CabinetBlock(Utils.copyPropertySafe(w.planks))
                 )
                 .requiresChildren("trapdoor", "slab") //REASON: recipes
-                .addTag(modRes("cabinets"), Registries.BLOCK)
-                .addTag(modRes("cabinets"), Registries.ITEM)
-                .addTag(modRes("cabinets/wooden"), Registries.ITEM)
                 .addTag(BlockTags.MINEABLE_WITH_AXE, Registries.BLOCK)
+                .addTag(modRes("cabinets/wooden"), Registries.ITEM)
                 .defaultRecipe()
                 .addTile(getModTile("cabinet"))
-                .setTabKey(modRes( "farmersdelight"))
+                .setTabKey(modRes("farmersdelight"))
                 .setTabMode(TabAddMode.AFTER_SAME_TYPE)
                 .createPaletteFromPlanks(p -> {
                     p.reduceDown();


### PR DESCRIPTION
Every Compat's cabinets (for Farmer's Delight) are currently failing to receive the "mineable/axe" block tag in game. This commit intends to bring further consistency with the tags in Farmer's Delight to hopefully solve the issue, along with some minor cleanup. Farmer's Delight does not create a block tag for cabinets, so that has been removed. The redundant addition of cabinets to the parent "cabinets" item tag has also been removed, as they are already added to the "cabinets/wooden" child.