### PR TITLE
[1.21] add more chest variants (lieonlion) for fabric

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -157,6 +157,7 @@ dependencies {
     modCompileOnly("curse.maven:lightmans-currency-fabric-724119:5544643") //!! Not maintained since 1.20.1
     modCompileOnly("curse.maven:mighty-mail-fabric-904097:4750271") //!! 1.20.1
     modCompileOnly("curse.maven:missing-wilds-622590:5579073")
+    modCompileOnly("curse.maven:more-chest-variants-lieonlion-858032:5476664")
     modCompileOnly("curse.maven:more-crafting-tables-lieonlion-913586:5473304")
     modCompileOnly("curse.maven:refurbished-furniture-897116:6272856") // Framework, Reflection - @DNU
     modCompileOnly("curse.maven:the-twilight-forest-227639:4389094") //!! NOT AVAILABLE

--- a/fabric/src/main/java/net/mehvahdjukaar/every_compat/fabric/EveryCompatFabric.java
+++ b/fabric/src/main/java/net/mehvahdjukaar/every_compat/fabric/EveryCompatFabric.java
@@ -16,6 +16,7 @@ import net.mehvahdjukaar.every_compat.modules.fabric.excessive_building.Excessiv
 import net.mehvahdjukaar.every_compat.modules.fabric.exlines.AwningModule;
 import net.mehvahdjukaar.every_compat.modules.fabric.infinitybuttons.InfinityButtonsModule;
 import net.mehvahdjukaar.every_compat.modules.fabric.lauchs.LauchsShuttersModule;
+import net.mehvahdjukaar.every_compat.modules.fabric.lieonlion.MoreChestVariantsModule;
 import net.mehvahdjukaar.every_compat.modules.fabric.lieonlion.MoreCraftingTablesModule;
 import net.mehvahdjukaar.every_compat.modules.fabric.lightmans_currency.LightmansCurrencyModule;
 import net.mehvahdjukaar.every_compat.modules.fabric.mcaw.*;
@@ -68,6 +69,7 @@ public class EveryCompatFabric extends EveryCompatCommon implements ModInitializ
         addIfLoaded("infinitybuttons", () -> InfinityButtonsModule::new);
         addIfLoaded("lightmanscurrency", () -> LightmansCurrencyModule::new); //!! Not maintained since 1.20.1
         addIfLoaded("lolmct", () -> MoreCraftingTablesModule::new);
+        addIfLoaded("lolmcv", () -> MoreChestVariantsModule::new);
         addIfLoaded("mighty_mail", () -> MightyMailModule::new);
         addIfLoaded("redbits", () -> RedBitsModule::new);
         addIfLoaded("regions_unexplored", () -> RegionsUnexploredModule::new);

--- a/fabric/src/main/java/net/mehvahdjukaar/every_compat/modules/fabric/lieonlion/MoreChestVariantsModule.java
+++ b/fabric/src/main/java/net/mehvahdjukaar/every_compat/modules/fabric/lieonlion/MoreChestVariantsModule.java
@@ -1,0 +1,190 @@
+package net.mehvahdjukaar.every_compat.modules.fabric.lieonlion;
+
+import com.google.gson.JsonObject;
+import io.github.lieonlion.mcv.init.McvBlockInit;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.mehvahdjukaar.every_compat.EveryCompat;
+import net.mehvahdjukaar.every_compat.api.SimpleEntrySet;
+import net.mehvahdjukaar.every_compat.api.SimpleModule;
+import net.mehvahdjukaar.every_compat.common_classes.CompatChestBlock;
+import net.mehvahdjukaar.every_compat.common_classes.CompatChestBlockEntity;
+import net.mehvahdjukaar.every_compat.common_classes.CompatChestBlockRenderer;
+import net.mehvahdjukaar.every_compat.common_classes.CompatTrappedChestBlock;
+import net.mehvahdjukaar.every_compat.dynamicpack.ClientDynamicResourcesHandler;
+import net.mehvahdjukaar.moonlight.api.platform.ClientHelper;
+import net.mehvahdjukaar.moonlight.api.resources.RPUtils;
+import net.mehvahdjukaar.moonlight.api.resources.ResType;
+import net.mehvahdjukaar.moonlight.api.set.wood.WoodType;
+import net.mehvahdjukaar.moonlight.api.set.wood.WoodTypeRegistry;
+import net.mehvahdjukaar.moonlight.api.util.Utils;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.world.item.CreativeModeTabs;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.ChestBlock;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.entity.ChestBlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.MapColor;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static net.mehvahdjukaar.every_compat.common_classes.CompatChestTexture.generateChestTexture;
+
+//SUPPORT: v1.5.4+
+public class MoreChestVariantsModule extends SimpleModule {
+    public final SimpleEntrySet<WoodType, ChestBlock> chests;
+    public final SimpleEntrySet<WoodType, ChestBlock> trappedChests;
+
+    public MoreChestVariantsModule(String modID) {
+        super(modID, "mcv");
+
+        chests = SimpleEntrySet.builder(
+                        WoodType.class,
+                        "chest",
+                        () -> McvBlockInit.OAK_CHEST,
+                        () -> WoodTypeRegistry.OAK_TYPE,
+                        w -> new CompatChestBlock(this::getChestTile,
+                                Utils.copyPropertySafe(Blocks.CHEST).mapColor(MapColor.WOOD))
+                )
+                .addTile(MoreChestBlockEntity::new)
+                .addTag(BlockTags.MINEABLE_WITH_AXE, Registries.BLOCK)
+                .addTag(BlockTags.GUARDED_BY_PIGLINS, Registries.BLOCK)
+                .addTag(ResourceLocation.parse("lieonstudio:chests/wooden"), Registries.BLOCK)
+                .addTag(ResourceLocation.parse("lieonstudio:chests/normal"), Registries.BLOCK)
+                .addTag(ResourceLocation.parse("c:chests"), Registries.BLOCK)
+                .addTag(ResourceLocation.parse("c:chests/wooden"), Registries.BLOCK)
+                .addTag(ResourceLocation.parse("quad:cats_on_blocks/sit"), Registries.BLOCK)
+                .addTag(ResourceLocation.parse("quad:fuel/wood"), Registries.ITEM)
+                .addTag(ResourceLocation.parse("c:chests"), Registries.ITEM)
+                .addTag(ResourceLocation.parse("c:chests/wooden"), Registries.ITEM)
+                .addTag(ResourceLocation.parse("lieonstudio:chests/normal"), Registries.ITEM)
+                .addTag(ResourceLocation.parse("lieonstudio:chests/wooden"), Registries.ITEM)
+                .setTabKey(CreativeModeTabs.FUNCTIONAL_BLOCKS)
+                .defaultRecipe()
+                .build();
+        this.addEntry(chests);
+
+        trappedChests = SimpleEntrySet.builder(
+                        WoodType.class,
+                        "trapped_chest",
+                        () -> McvBlockInit.OAK_TRAPPED_CHEST,
+                        () -> WoodTypeRegistry.OAK_TYPE,
+                        w -> new CompatTrappedChestBlock(this::getTrappedTile,
+                                Utils.copyPropertySafe(Blocks.TRAPPED_CHEST).mapColor(MapColor.WOOD))
+                )
+                .addTile(MoreTrappedBlockEntity::new)
+                .addTag(ResourceLocation.parse("lieonstudio:chests/wooden"), Registries.BLOCK)
+                .addTag(ResourceLocation.parse("lieonstudio:chests/trapped"), Registries.BLOCK)
+                .addTag(BlockTags.MINEABLE_WITH_AXE, Registries.BLOCK)
+                .addTag(BlockTags.GUARDED_BY_PIGLINS, Registries.BLOCK)
+                .addTag(ResourceLocation.parse("c:chests"), Registries.BLOCK)
+                .addTag(ResourceLocation.parse("c:chests/wooden"), Registries.BLOCK)
+                .addTag(ResourceLocation.parse("quad:fuel/wood"), Registries.ITEM)
+                .addTag(ResourceLocation.parse("lieonstudio:chests/trapped"), Registries.ITEM)
+                .addTag(ResourceLocation.parse("lieonstudio:chests/wooden"), Registries.ITEM)
+                .addTag(ResourceLocation.parse("c:chests"), Registries.ITEM)
+                .addTag(ResourceLocation.parse("c:chests/wooden"), Registries.ITEM)
+                .setTabKey(CreativeModeTabs.REDSTONE_BLOCKS)
+                .defaultRecipe()
+                .build();
+        this.addEntry(trappedChests);
+
+    }
+
+    // GetTile ---------------------------------------------------------------------------------------------------------
+    private BlockEntityType<? extends ChestBlockEntity> getChestTile() {
+        return chests.getTile(CompatChestBlockEntity.class);
+    }
+
+    private BlockEntityType<? extends ChestBlockEntity> getTrappedTile() {
+        return trappedChests.getTile(CompatChestBlockEntity.class);
+    }
+
+    // BlockEntity -----------------------------------------------------------------------------------------------------
+    private class MoreChestBlockEntity extends CompatChestBlockEntity {
+        public MoreChestBlockEntity(BlockPos pos, BlockState state) {
+            super(chests.getTile(), pos, state);
+        }
+    }
+
+    private class MoreTrappedBlockEntity extends CompatChestBlockEntity {
+        public MoreTrappedBlockEntity(BlockPos pos, BlockState state) {
+            super(trappedChests.getTile(), pos, state);
+        }
+    }
+
+    // Registry --------------------------------------------------------------------------------------------------------
+    @Override
+    @Environment(EnvType.CLIENT)
+    public void registerBlockEntityRenderers(ClientHelper.BlockEntityRendererEvent event) {
+        super.registerBlockEntityRenderers(event);
+        CompatChestBlockRenderer.register(event, chests.getTile(CompatChestBlockEntity.class), shortenedId());
+        CompatChestBlockRenderer.register(event, trappedChests.getTile(CompatChestBlockEntity.class), shortenedId());
+    }
+
+    // Textures
+    @Override
+    public void addDynamicClientResources(ClientDynamicResourcesHandler handler, ResourceManager manager) {
+        super.addDynamicClientResources(handler, manager);
+
+        trappedChests.blocks.forEach((wood, block) -> {
+            // SINGLE
+            generateChestTexture(handler, manager, shortenedId(), wood, block,
+                    modRes("entity/chest/oak"),
+                    EveryCompat.res("entity/mcv_chest_normal_m"),
+                    EveryCompat.res("entity/mcv_chest_normal_o"),
+                    EveryCompat.res("entity/mcv_trapped_normal_o"), 0
+            );
+            // LEFT
+            generateChestTexture(handler, manager, shortenedId(), wood, block,
+                    modRes("entity/chest/oak_left"),
+                    EveryCompat.res("entity/mcv_chest_left_m"),
+                    EveryCompat.res("entity/mcv_chest_left_o"),
+                    EveryCompat.res("entity/mcv_trapped_left_o"), 0
+            );
+            // RIGHT
+            generateChestTexture(handler, manager, shortenedId(), wood, block,
+                    modRes("entity/chest/oak_right"),
+                    EveryCompat.res("entity/mcv_chest_right_m"),
+                    EveryCompat.res("entity/mcv_chest_right_o"),
+                    EveryCompat.res("entity/mcv_trapped_right_o"), 0
+            );
+
+
+            // MODEL BLOCK
+            String path = shortenedId() + "/" + wood.getAppendableId() + "_chest";
+            String trapped_path = shortenedId() + "/" + wood.getAppendableId() + "_trapped_chest";
+
+            customModel(path, handler, manager);
+            customModel(trapped_path, handler, manager);
+        });
+
+    }
+
+    public void customModel(String path, ClientDynamicResourcesHandler handler, ResourceManager manager) {
+        JsonObject modelFile;
+        ResourceLocation modelRLoc = EveryCompat.res("models/block/" + path + ".json");
+
+        if (manager.getResource(modelRLoc).isPresent()) {
+            try (InputStream modelStream = manager.getResource(modelRLoc).get().open()) {
+                modelFile = RPUtils.deserializeJson(modelStream);
+
+                String textureID = EveryCompat.MOD_ID + ":entity/chest/" + path;
+
+                // Editing
+                modelFile.getAsJsonObject("textures").addProperty("wood_type", textureID);
+
+                // Add to Resource
+                handler.dynamicPack.addJson(EveryCompat.res(path), modelFile, ResType.BLOCK_MODELS);
+            } catch (IOException e) {
+                EveryCompat.LOGGER.error("MoreChestVariantsModule: failed to open the model file: {} - {}", modelRLoc, e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
![2025-06-08_01 26 03](https://github.com/user-attachments/assets/399c3f78-60f8-4715-8450-e559d2b1e17d)

Ported the Forge code, to add chest/trapped-chest compat for More Chest Variants to its equivalent Fabric release, and seems to work swimmingly! 

Well, when done in here, when trying to implement the module on a brand new project, or the original mod, it kept erroring out while trying to load client classes inside a properly delineated method...

Seems related to [!365](https://github.com/MehVahdJukaar/WoodGood/issues/365)