### PR TITLE
Added No Man's Land Support

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/every_compat/api/AbstractSimpleEntrySet.java
+++ b/common/src/main/java/net/mehvahdjukaar/every_compat/api/AbstractSimpleEntrySet.java
@@ -455,6 +455,12 @@ public abstract class AbstractSimpleEntrySet<T extends BlockType, B extends Bloc
             return addTexture(TextureInfo.of(textureLocation, customTexturePath));
         }
 
+        // edge case for when a custom path (for the correct ResourceLocation) is required with a mask simultaneously
+        public BL addTextureCM(ResourceLocation textureLocation, ResourceLocation maskLocation, String customTexturePath) {
+            return addTexture(TextureInfo.of(textureLocation, customTexturePath)
+                    .mask(maskLocation));
+        }
+
         // adds a texture with automatic masking. Experimental
         public BL addTextureAutoM(ResourceLocation textureLocation) {
             return addTexture(TextureInfo.of(textureLocation)

--- a/common/src/main/resources/assets/everycomp/lang/en_us.json
+++ b/common/src/main/resources/assets/everycomp/lang/en_us.json
@@ -1107,5 +1107,8 @@
   "block_type.bibliocraft.potion_shelf": "%s Potion Shelf",
   "block_type.bibliocraft.shelf": "%s Shelf",
   "block_type.bibliocraft.table": "%s Table",
-  "block_type.bibliocraft.tool_rack": "%s Tool Rack"
+  "block_type.bibliocraft.tool_rack": "%s Tool Rack",
+
+  "block_type.nomansland.trimmed_planks": "Trimmed %s Planks",
+  "block_type.nomansland.bookshelf": "%s Bookshelf"
 }

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -232,6 +232,7 @@ dependencies {
     modCompileOnly("curse.maven:missing-wilds-622590:5569350")
     modCompileOnly("curse.maven:more-crafting-tables-for-forge-417365:6002554") //CRAFTING_TABLES for FORGE
     modCompileOnly("curse.maven:mosaic-carpentry-690226:4068673") //!! 1.20.1
+    modCompileOnly("curse.maven:no-mans-land-538493:6937950")
     modCompileOnly("curse.maven:oreberries-replanted-454062:5817304")
     modCompileOnly("curse.maven:pokecube-aoi-285121:6920497")
     modCompileOnly("curse.maven:premium-wood-353515:3905203") //!! 1.20.1

--- a/neoforge/src/main/java/net/mehvahdjukaar/every_compat/modules/neoforge/nomansland/NoMansLandModule.java
+++ b/neoforge/src/main/java/net/mehvahdjukaar/every_compat/modules/neoforge/nomansland/NoMansLandModule.java
@@ -1,0 +1,55 @@
+package net.mehvahdjukaar.every_compat.modules.neoforge.nomansland;
+
+import com.farcr.nomansland.common.block.TrimmedPlankBlock;
+import net.mehvahdjukaar.every_compat.EveryCompat;
+import net.mehvahdjukaar.every_compat.api.SimpleEntrySet;
+import net.mehvahdjukaar.every_compat.api.SimpleModule;
+import net.mehvahdjukaar.moonlight.api.set.wood.VanillaWoodTypes;
+import net.mehvahdjukaar.moonlight.api.set.wood.WoodType;
+import net.mehvahdjukaar.moonlight.api.util.Utils;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.world.level.block.Block;
+
+public class NoMansLandModule extends SimpleModule {
+
+    public final SimpleEntrySet<WoodType, Block> trimmedPlanks,
+            bookshelf;
+
+    public NoMansLandModule(String modId) {
+        super(modId, "nml", EveryCompat.MOD_ID);
+
+        ResourceLocation tab = modRes(modId);
+
+        trimmedPlanks = SimpleEntrySet.builder(WoodType.class, "planks", "trimmed",
+                        getModBlock("trimmed_oak_planks"), () -> VanillaWoodTypes.OAK,
+                        w -> new TrimmedPlankBlock(Utils.copyPropertySafe(w.planks)))
+                .addTexture(modRes("block/vanilla_woods/trimmed_oak_planks"))
+                .addTexture(modRes("block/vanilla_woods/trimmed_oak_planks_lower"))
+                .addTexture(modRes("block/vanilla_woods/trimmed_oak_planks_middle"))
+                .addTexture(modRes("block/vanilla_woods/trimmed_oak_planks_upper"))
+                .addTexture(modRes("block/vanilla_woods/trimmed_oak_planks_top"))
+                .addTag(BlockTags.MINEABLE_WITH_AXE, Registries.BLOCK)
+                .addTag(modRes("trimmed_planks"), Registries.BLOCK, Registries.ITEM)
+                .addRecipe(modRes("wood/vanilla_woods/trimmed_oak_planks"))
+                .setTabKey(tab)
+                .build();
+        this.addEntry(trimmedPlanks);
+
+        bookshelf = SimpleEntrySet.builder(WoodType.class, "bookshelf",
+                        getModBlock("acacia_bookshelf"), () -> VanillaWoodTypes.ACACIA,
+                        w -> new Block(Utils.copyPropertySafe(w.planks).strength(1.5F)))
+                .addTextureCM(EveryCompat.res("block/acacia_bookshelf"), EveryCompat.res("block/acacia_bookshelf_m"), "block/vanilla_woods/acacia_bookshelf")
+                .addTextureCM(EveryCompat.res("block/acacia_bookshelf"), EveryCompat.res("block/acacia_bookshelf_m"), "block/vanilla_woods/acacia_bookshelf_alt")
+                .addTag(BlockTags.MINEABLE_WITH_AXE, Registries.BLOCK)
+                .addTag(modRes("bookshelves"), Registries.BLOCK, Registries.ITEM)
+                .addRecipe(modRes("wood/vanilla_woods/acacia_bookshelf"))
+                .copyParentDrop()
+                .setTabKey(tab)
+                .build();
+        this.addEntry(bookshelf);
+
+    }
+
+}

--- a/neoforge/src/main/java/net/mehvahdjukaar/every_compat/neoforge/EveryCompatForge.java
+++ b/neoforge/src/main/java/net/mehvahdjukaar/every_compat/neoforge/EveryCompatForge.java
@@ -27,6 +27,7 @@ import net.mehvahdjukaar.every_compat.modules.neoforge.mcaw.*;
 import net.mehvahdjukaar.every_compat.modules.neoforge.more.MoreCraftingTablesForForgeModule;
 import net.mehvahdjukaar.every_compat.modules.neoforge.mosaic_carpentry.MosaicCarpentryModule;
 import net.mehvahdjukaar.every_compat.modules.neoforge.mrcrayfish.MightyMailModule;
+import net.mehvahdjukaar.every_compat.modules.neoforge.nomansland.NoMansLandModule;
 import net.mehvahdjukaar.every_compat.modules.neoforge.oreberries_replanted.OreberriesReplantedModule;
 import net.mehvahdjukaar.every_compat.modules.neoforge.pokecube.PokecubeAIOModule;
 import net.mehvahdjukaar.every_compat.modules.neoforge.premium_wood.PremiumWoodModule;
@@ -112,6 +113,7 @@ public class EveryCompatForge extends EveryCompatCommon {
             addIfLoaded("mctb", () -> MoreCraftingTablesForForgeModule::new);
             addIfLoaded("mighty_mail", () -> MightyMailModule::new);
             addIfLoaded("mosaic_carpentry", () -> MosaicCarpentryModule::new);
+            addIfLoaded("nomansland", () -> NoMansLandModule::new);
             addIfLoaded("oreberriesreplanted", () -> OreberriesReplantedModule::new);
             addIfLoaded("lightmanscurrency", () -> LightmansCurrencyModule::new);
             addIfLoaded("pokecube_legends", () -> PokecubeAIOModule::new);


### PR DESCRIPTION
Heya! This is the implementation for the mod [No Man's Land](https://modrinth.com/mod/no-mans-land). It's a less-downloaded mod but it's growing fast. I've kept to all of the examples set by the other modules as best I can, but please let me know if there's any formatting mistakes or such. I have tested it in-game and it's all functional (Neoforge 21.1.209, all other mods latest ver).

Some notes:
I have added a new function in AbstractSimpleEntrySet.java called `addTextureCM()`, as the bookshelf blocks from nml required both a mask for the books, and a custom path because they exist in a sub-folder.

Also I noticed a bug that occurs with not just my module, but others too so I know it's not my code that's wrong. I haven't checked the issue tracker though so sorry if it's already been brought up. With blocks like the bookshelf, the loot table does not function. When breaking with silk touch it does drop itself, but regular breaking it drops nothing when it should drop 3 books. I have also tested this with Woodworks bookshelves and get the same result.