### PR TITLE
Updated EveryCompatModule tutorial on the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ To register a custom module and non-detected wood type in your mod:
 
 If you want a **high detail level** example of how is this applied, then you can check below:
 1. [GuitaWoodworks-Init](https://github.com/macuguita/woodworks/blob/1.20.1/common/src/main/java/com/macuguita/woodworks/GuitaWoodworks.java#L57) - Initization
-2. [GuitaWoodworks-EveryCompatModule](https://github.com/macuguita/woodworks/blob/1.21.1/common/src/main/java/com/macuguita/woodworks/GuitaWoodworks.java#L105) - Checking if EveryCompat is installed 
+2. [GuitaWoodworks-EveryCompatModule](https://github.com/macuguita/woodworks/blob/1.21.1/common/src/main/java/com/macuguita/woodworks/GuitaWoodworks.java#L161) - Checking if EveryCompat is installed 
 3. [ModCompat](https://github.com/macuguita/woodworks/blob/1.20.1/common/src/main/java/com/macuguita/woodworks/compat/ModCompat.java) - Using `EveryCompatAPI.registerModule(...)`
 4. [WoodGoodModule](https://github.com/macuguita/woodworks/blob/1.20.1/common/src/main/java/com/macuguita/woodworks/compat/WoodGood.java)
 


### PR DESCRIPTION
Since my mod was originally used as an example and some internal changes have been made since then, the referenced line numbers no longer pointed to the correct locations. I’ve updated them so they now align properly, with the references pointing to the correct lines based on the updated check for whether EveryCompat is loaded.
